### PR TITLE
add oidc client auth import

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	_ "github.com/golang/glog"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"github.com/stefanprodan/kubectl-kubesec/pkg/cmd"
 	"os"
 	"strings"


### PR DESCRIPTION
Hello, 

This fixes https://github.com/stefanprodan/kubectl-kubesec/issues/3 by adding the oidc authentication import.

This is for example needed to authenticate to IBM-Cloud clusters.