### PR TITLE
Upgrade plugin to kubesec v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 language: go
 
 go:
-  - 1.11.x
+  - 1.12.x
 
 script:
   - make deploy

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ V?=0
 
 deploy:
 	@mkdir -p ~/.kube/plugins/
+	@rm -rf ~/.kube/plugins/kubectl-scan || true
 	@go build -o ~/.kube/plugins/kubectl-scan
 
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # kubectl-kubesec
 
-[![Build Status](https://travis-ci.org/stefanprodan/kubectl-kubesec.svg?branch=master)](https://travis-ci.org/stefanprodan/kubectl-kubesec)
+[![Build Status](https://travis-ci.org/controlplaneio/kubectl-kubesec.svg?branch=master)](https://travis-ci.org/controlplaneio/kubectl-kubesec)
 
 This is a kubectl plugin for scanning Kubernetes pods, deployments, daemonsets and statefulsets with [kubesec.io](https://kubesec.io)
 
-For the admission controller see [kubesec-webhook](https://github.com/stefanprodan/kubesec-webhook)
+For the admission controller see [kubesec-webhook](https://github.com/controlplaneio/kubesec-webhook)
 
 ### Install
 
@@ -21,7 +21,7 @@ For Kubernetes 1.12 or newer:
 
 ```bash
 mkdir -p ~/.kube/plugins/scan && \
-curl -sL https://github.com/stefanprodan/kubectl-kubesec/releases/download/1.0.0/kubectl-kubesec_1.0.0_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
+curl -sL https://github.com/controlplaneio/kubectl-kubesec/releases/download/1.0.0/kubectl-kubesec_1.0.0_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
 mv ~/.kube/plugins/scan/scan ~/.kube/plugins/scan/kubectl-scan
 export PATH=$PATH:~/.kube/plugins/scan
 ```
@@ -30,7 +30,7 @@ For Kubernetes older than 1.12:
 
 ```bash
 mkdir -p ~/.kube/plugins/scan && \
-curl -sL https://github.com/stefanprodan/kubectl-kubesec/releases/download/0.3.1/kubectl-kubesec_0.3.1_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
+curl -sL https://github.com/controlplaneio/kubectl-kubesec/releases/download/0.3.1/kubectl-kubesec_0.3.1_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
 ```
 
 ### Usage
@@ -68,17 +68,33 @@ kubectl scan -n weave daemonset weave-scope-agent
 Result:
 
 ```
-daemonset/weave-scope-agent kubesec.io score -54
+kubesec.io score: -51
 -----------------
 Critical
-1. containers[] .securityContext .privileged == true
-Privileged containers can allow almost completely unrestricted host access
-2. .spec .hostNetwork
+1. .spec .hostNetwork == true
 Sharing the host's network namespace permits processes in the pod to communicate with processes bound to the host's loopback adapter
-3. .spec .hostPID
+2. .spec .hostPID == true
 Sharing the host's PID namespace allows visibility of processes on the host, potentially leaking information such as environment variables and configuration
-4. .spec .volumes[] .hostPath .path == "/var/run/docker.sock"
+3. containers[] .securityContext .privileged == true
+Privileged containers can allow almost completely unrestricted host access
+4. volumes[] .hostPath .path == /var/run/docker.sock
 Mounting the docker.socket leaks information about other containers and can allow container breakout
+-----------------
+Advise
+1. containers[] .securityContext .runAsUser -gt 10000
+Run as a high-UID user to avoid conflicts with the host's user table
+2. containers[] .securityContext .readOnlyRootFilesystem == true
+An immutable root filesystem can prevent malicious binaries being added to PATH and increase attack cost
+3. containers[] .securityContext .runAsNonRoot == true
+Force the running image to run as a non-root user to ensure least privilege
+4. containers[] .resources .limits .cpu
+Enforcing CPU limits prevents DOS via resource exhaustion
+5. containers[] .securityContext .capabilities .drop
+Reducing kernel capabilities available to a container limits its attack surface
+6. .metadata .annotations ."container.seccomp.security.alpha.kubernetes.io/pod"
+Seccomp profiles set minimum privilege and secure against unknown threats
+7. containers[] .securityContext .capabilities .drop | index("ALL")
+Drop all capabilities and add only those required to reduce syscall attack surface
 ```
 
 Scan a StatefulSet:

--- a/README.md
+++ b/README.md
@@ -143,3 +143,5 @@ Run as a high-UID user to avoid conflicts with the host's user table
 5. containers[] .securityContext .capabilities .drop | index("ALL")
 Drop all capabilities and add only those required to reduce syscall attack surface
 ```
+
+Note that you can change the kubesec API address with the `KUBESEC_URL` env var.

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/cmd"
 	_ "github.com/golang/glog"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/cmd"
 	"os"
 	"strings"
 )

--- a/pkg/cmd/daemonset.go
+++ b/pkg/cmd/daemonset.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/kubesec"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/kubesec"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/kubesec"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/kubesec"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/kubesec"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/kubesec"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )

--- a/pkg/cmd/statefulset.go
+++ b/pkg/cmd/statefulset.go
@@ -5,8 +5,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/kubesec"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/kubesec"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/version"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/version"
 )
 
 var versionCmd = &cobra.Command{

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
 package version
 
-var VERSION = "1.0.0"
+var VERSION = "2.0.0"
 var REVISION = "unknown"


### PR DESCRIPTION
Use kubesec v2 API and allow overriding the kubesec URL with `export KUBESEC_URL=https://v2.kubesec.io/scan`
