### PR TITLE
Updated repo location to controlplaneio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # kubectl-kubesec
 
-[![Build Status](https://travis-ci.org/stefanprodan/kubectl-kubesec.svg?branch=master)](https://travis-ci.org/stefanprodan/kubectl-kubesec)
+[![Build Status](https://travis-ci.org/controlplaneio/kubectl-kubesec.svg?branch=master)](https://travis-ci.org/controlplaneio/kubectl-kubesec)
 
 This is a kubectl plugin for scanning Kubernetes pods, deployments, daemonsets and statefulsets with [kubesec.io](https://kubesec.io)
 
-For the admission controller see [kubesec-webhook](https://github.com/stefanprodan/kubesec-webhook)
+For the admission controller see [kubesec-webhook](https://github.com/controlplaneio/kubesec-webhook)
 
 ### Install
 
@@ -21,7 +21,7 @@ For Kubernetes 1.12 or newer:
 
 ```bash
 mkdir -p ~/.kube/plugins/scan && \
-curl -sL https://github.com/stefanprodan/kubectl-kubesec/releases/download/1.0.0/kubectl-kubesec_1.0.0_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
+curl -sL https://github.com/controlplaneio/kubectl-kubesec/releases/download/1.0.0/kubectl-kubesec_1.0.0_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
 mv ~/.kube/plugins/scan/scan ~/.kube/plugins/scan/kubectl-scan
 export PATH=$PATH:~/.kube/plugins/scan
 ```
@@ -30,7 +30,7 @@ For Kubernetes older than 1.12:
 
 ```bash
 mkdir -p ~/.kube/plugins/scan && \
-curl -sL https://github.com/stefanprodan/kubectl-kubesec/releases/download/0.3.1/kubectl-kubesec_0.3.1_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
+curl -sL https://github.com/controlplaneio/kubectl-kubesec/releases/download/0.3.1/kubectl-kubesec_0.3.1_`uname -s`_amd64.tar.gz | tar xzvf - -C ~/.kube/plugins/scan
 ```
 
 ### Usage

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 	_ "github.com/golang/glog"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/cmd"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/cmd"
 	"os"
 	"strings"
 )

--- a/pkg/cmd/daemonset.go
+++ b/pkg/cmd/daemonset.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/kubesec"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/kubesec"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/kubesec"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/kubesec"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/kubesec"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/kubesec"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )

--- a/pkg/cmd/statefulset.go
+++ b/pkg/cmd/statefulset.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/kubesec"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/kubesec"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 	"github.com/spf13/cobra"
-	"github.com/stefanprodan/kubectl-kubesec/pkg/version"
+	"github.com/controlplaneio/kubectl-kubesec/pkg/version"
 )
 
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
Build status on master showing as unknown rather than passed. The README had stefanprodan repos as checking sources. This fix points it to the new home. Also changes to cmd/*.go.