### PR TITLE
feat: add LICENSE to release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,7 @@ archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     files:
       - plugin.yaml
+      - LICENSE
 
 snapshot:
   name_template: "{{ .Tag }}-next"


### PR DESCRIPTION
- closes #22
- krew-index requires license within the release
- add LICENSE to archives