### PR TITLE
feature: add support for API v2, custom URLs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,20 @@
+---
+name: Go
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Run unit tests
+        run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![Build Status](https://travis-ci.org/controlplaneio/kubectl-kubesec.svg?branch=master)](https://travis-ci.org/controlplaneio/kubectl-kubesec)
 
-This is a kubectl plugin for scanning Kubernetes pods, deployments, daemonsets and statefulsets with [kubesec.io](https://kubesec.io)
+This is a kubectl plugin for scanning Kubernetes pods, deployments, daemonsets and statefulsets with [kubesec.io](https://kubesec.io). By default the plugin will send scan requests to the hosted version of [kubesec.io](https://kubesec.io). However, it is also possible to self host the scanning service and use that for scanning instead.
 
 For the admission controller see [kubesec-webhook](https://github.com/controlplaneio/kubesec-webhook)
 
-### Install
+The latest release of this plugin is fully compatible with the API version V2 of kubesec documented at [kubesec.io](https://kubesec.io).
 
 #### Install with krew
 
@@ -35,15 +35,24 @@ curl -sL https://github.com/controlplaneio/kubectl-kubesec/releases/download/0.3
 
 ### Usage
 
+By default the plugin uses the hosted version of [kubesec.io](https://kubesec.io). However, you can run the hosted service locally. For example using docker:
+
+```bash
+## 
+docker run -d -p 8080:8080 kubesec/kubesec:v2 http 8080
+```
+
 Scan a Deployment:
 
 ```bash
 kubectl kubesec-scan -n kube-system deployment kubernetes-dashboard
+# if you are running a self hosted version of kubese.io using docker then:
+kubectl kubesec-scan -n kube-system deployment kubernetes-dashboard --url http://localhost:8080
 ```
 
 Result:
 
-```
+```bash
 kubernetes-dashboard kubesec.io score 7
 -----------------
 Advise
@@ -63,11 +72,13 @@ Scan a DaemonSet:
 
 ```bash
 kubectl kubesec-scan -n weave daemonset weave-scope-agent
+# if you are running a self hosted version of kubese.io using then:
+kubectl kubesec-scan -n weave daemonset weave-scope-agent --url http://localhost:8080
 ```
 
 Result:
 
-```
+```bash
 daemonset/weave-scope-agent kubesec.io score -54
 -----------------
 Critical
@@ -85,11 +96,13 @@ Scan a StatefulSet:
 
 ```bash
 kubectl kubesec-scan statefulset memcached
+# if you are running a self hosted version of kubese.io then:
+kubectl kubesec-scan statefulset memcached --url http://localhost:8080
 ```
 
 Result:
 
-```
+```bash
 statefulset/memcached kubesec.io score 2
 -----------------
 Advise
@@ -108,11 +121,13 @@ Scan a Pod:
 
 ```bash
 kubectl kubesec-scan -n kube-system pod tiller-deploy-5c688d5f9b-ztjbt
+# if you are running a self hosted version of kubese.io then:
+kubectl kubesec-scan -n kube-system pod tiller-deploy-5c688d5f9b-ztjbt --url http://localhost:8080 
 ```
 
 Result:
 
-```
+```bash
 pod/tiller-deploy-5c688d5f9b-ztjbt kubesec.io score 3
 -----------------
 Advise

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/spf13/cobra v1.2.1
+	github.com/stretchr/testify v1.7.0 // indirect
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
 )

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/cmd/daemonset.go
+++ b/pkg/cmd/daemonset.go
@@ -45,19 +45,22 @@ var daemonsetCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		writer.Flush()
+		if err := writer.Flush(); err != nil {
+			return err
+		}
 
-		result, err := kubesec.NewClient().ScanDefinition(buffer)
+		kc := kubesec.NewClient(scanURL, scanTimeOut)
+		rs, err := kc.ScanDefinition(buffer)
+
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		if result.Error != "" {
-			fmt.Println(result.Error)
+
+		if err := rs.Dump(os.Stdout); err != nil {
+			fmt.Println(err)
 			os.Exit(1)
 		}
-
-		result.Dump(os.Stdout)
 
 		return nil
 	},

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -45,19 +45,23 @@ var deploymentCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		writer.Flush()
+		if err := writer.Flush(); err != nil {
+			return err
+		}
 
-		result, err := kubesec.NewClient().ScanDefinition(buffer)
+		kc := kubesec.NewClient(scanURL, scanTimeOut)
+
+		rs, err := kc.ScanDefinition(buffer)
+
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		if result.Error != "" {
-			fmt.Println(result.Error)
+
+		if err := rs.Dump(os.Stdout); err != nil {
+			fmt.Println(err)
 			os.Exit(1)
 		}
-
-		result.Dump(os.Stdout)
 
 		return nil
 	},

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -45,19 +45,22 @@ var podCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		writer.Flush()
+		if err := writer.Flush(); err != nil {
+			return err
+		}
 
-		result, err := kubesec.NewClient().ScanDefinition(buffer)
+		kc := kubesec.NewClient(scanURL, scanTimeOut)
+		rs, err := kc.ScanDefinition(buffer)
+
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		if result.Error != "" {
-			fmt.Println(result.Error)
+
+		if err := rs.Dump(os.Stdout); err != nil {
+			fmt.Println(err)
 			os.Exit(1)
 		}
-
-		result.Dump(os.Stdout)
 
 		return nil
 	},

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -19,14 +19,18 @@ kubesec.io command line utilities`,
 }
 
 var (
-	namespace  string
-	kubeClient *kubernetes.Clientset
-	serializer *kjson.Serializer
+	namespace   string
+	kubeClient  *kubernetes.Clientset
+	serializer  *kjson.Serializer
+	scanTimeOut int
+	scanURL     string
 )
 
 func init() {
 	// global flags
 	RootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "Kubernetes namespace")
+	RootCmd.PersistentFlags().IntVarP(&scanTimeOut, "timeout", "t", 120, "Scan timeout in seconds")
+	RootCmd.PersistentFlags().StringVarP(&scanURL, "url", "u", "https://v2.kubesec.io", "URL to send the request for scanning")
 
 	// client
 	kubeClient = loadConfig()

--- a/pkg/cmd/statefulset.go
+++ b/pkg/cmd/statefulset.go
@@ -45,19 +45,22 @@ var statefulsetCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		writer.Flush()
+		if err := writer.Flush(); err != nil {
+			return err
+		}
 
-		result, err := kubesec.NewClient().ScanDefinition(buffer)
+		kc := kubesec.NewClient(scanURL, scanTimeOut)
+		rs, err := kc.ScanDefinition(buffer)
+
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)
 		}
-		if result.Error != "" {
-			fmt.Println(result.Error)
+
+		if err := rs.Dump(os.Stdout); err != nil {
+			fmt.Println(err)
 			os.Exit(1)
 		}
-
-		result.Dump(os.Stdout)
 
 		return nil
 	},

--- a/pkg/kubesec/kubesec_test.go
+++ b/pkg/kubesec/kubesec_test.go
@@ -1,0 +1,132 @@
+package kubesec
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// NewHTTPTestServer - Returns a new instances of httptest server with pre-determined response
+func NewHTTPTestServer(code int, body string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(code)
+		_, err := w.Write([]byte(body))
+		if err != nil {
+			fmt.Println("error writing HTTP response")
+		}
+	}))
+}
+
+func TestKubesecClient_ScanDefinition(t *testing.T) {
+	testCases := []struct {
+		name             string
+		mockResponseCode int
+		mockResponseBody string
+		wantErr          bool
+		timeOutSec       int
+		wantScore        int
+		errorString      string
+	}{
+		{"Test non 200 response", 500, `validResp`, true, 5, 6, "got 500 response"},
+		{"Test 200 response but with empty result", 200, ``, true, 5, 6, "failed to scan definition"},
+		{"Test 200 response but with invalid result json", 200, `"foo": "bar"`, true, 5, 6, "invalid character"},
+		{"Test timeout", 200, `"foo": "bar"`, true, 0, 6, "context deadline exceeded"},
+		{"Test valid response with valid score", 200, `[{"score": 6,"scoring": {}}]`, false, 10, 6, ""},
+		{"Test with an Error field set to non-empty string", 200, `[{"score": 60,"error": "dummyError"}]`, false, 10, 60, ""},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var b bytes.Buffer
+			server := NewHTTPTestServer(tc.mockResponseCode, tc.mockResponseBody)
+
+			defer server.Close()
+
+			kc := NewClient(server.URL, tc.timeOutSec)
+
+			// our http handler does not care about the data being sent
+			_, err := b.WriteString(`dummyPost`)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			result, err := kc.ScanDefinition(b)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errorString)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, result[0].Score, tc.wantScore)
+			}
+		})
+	}
+}
+
+func TestKubeSecResults(t *testing.T) {
+
+	responseWithOutError := `
+	[{
+	"score": -36,
+	"scoring": {
+		"critical": [{
+				"id": "Privileged",
+				"selector": "containers[] .securityContext .privileged == true",
+				"reason": "Privileged containers can allow almost completely unrestricted host access",
+				"points": -30
+			},
+			{
+				"id": "HostNetwork",
+				"selector": ".spec .hostNetwork == true",
+				"reason": "Sharing the host's network namespace permits processes in the pod to communicate with processes bound to the host's loopback adapter",
+				"points": -9
+			}
+		]
+	}
+	}]
+	`
+	validOutput := "kubesec.io score: -36\n-----------------\nCritical\n1. containers[] .securityContext .privileged == true\n" +
+		"Privileged containers can allow almost completely unrestricted host access\n2. .spec .hostNetwork == true\n" +
+		"Sharing the host's network namespace permits processes in the pod to communicate with " +
+		"processes bound to the host's loopback adapter\n-----------------\n"
+
+	testCases := []struct {
+		name     string
+		response string
+		want     string
+		wantErr  bool
+	}{
+		{"response with error field not set", responseWithOutError, validOutput, false},
+		{"response with error field set", `[{"score": -36,"error":"dummyError"}]`, "", true},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var results KubeSecResults
+			var b bytes.Buffer
+
+			err := json.Unmarshal([]byte(tc.response), &results)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = results.Dump(&b)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, b.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR:
- Add supports for the API version v2 of the kubesec documented at https://kubesec.io/
- Adds support for custom scan URLs and timeouts. It is possible to point the plugin to a self hosted version of `kubesec`. For example:
```
docker run -d -p 8080:8080 kubesec/kubesec:v2 http 8080
kubectl kubectl-kubesec daemonset -n kube-system kube-proxy --url http://localhost:8080
```
- Adds units tests and runs the same using github actions
