### PR TITLE
fix: load kubeconfig like kubectl

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,23 +1,9 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"os"
-	"strings"
-
 	"github.com/controlplaneio/kubectl-kubesec/v2/pkg/cmd"
 )
 
-func init() {
-	flag.CommandLine.Set("logtostderr", "true")
-}
-
 func main() {
-	cmd.RootCmd.SetArgs(os.Args[1:])
-	if err := cmd.RootCmd.Execute(); err != nil {
-		e := err.Error()
-		fmt.Println(strings.ToUpper(e[:1]) + e[1:])
-		os.Exit(1)
-	}
+	cmd.Execute()
 }

--- a/pkg/cmd/daemonset.go
+++ b/pkg/cmd/daemonset.go
@@ -24,6 +24,11 @@ var daemonsetCmd = &cobra.Command{
 		}
 		name := args[0]
 
+		kubeClient, err := newKubeClient(kubeconfig)
+		if err != nil {
+			return err
+		}
+
 		var buffer bytes.Buffer
 		writer := bufio.NewWriter(&buffer)
 

--- a/pkg/cmd/deployment.go
+++ b/pkg/cmd/deployment.go
@@ -24,6 +24,11 @@ var deploymentCmd = &cobra.Command{
 		}
 		name := args[0]
 
+		kubeClient, err := newKubeClient(kubeconfig)
+		if err != nil {
+			return err
+		}
+
 		var buffer bytes.Buffer
 		writer := bufio.NewWriter(&buffer)
 

--- a/pkg/cmd/pod.go
+++ b/pkg/cmd/pod.go
@@ -24,6 +24,11 @@ var podCmd = &cobra.Command{
 		}
 		name := args[0]
 
+		kubeClient, err := newKubeClient(kubeconfig)
+		if err != nil {
+			return err
+		}
+
 		var buffer bytes.Buffer
 		writer := bufio.NewWriter(&buffer)
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,76 +1,84 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 	kjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var RootCmd = &cobra.Command{
+var rootCmd = &cobra.Command{
 	Use:   "scan",
 	Short: "kubesec.io kubectl plugin",
 	Long: `
 kubesec.io command line utilities`,
+	SilenceUsage: true,
 }
 
 var (
-	namespace   string
-	kubeClient  *kubernetes.Clientset
-	serializer  *kjson.Serializer
-	scanTimeOut int
-	scanURL     string
+	namespace, kubeconfig string
+	serializer            *kjson.Serializer
+	scanTimeOut           int
+	scanURL               string
 )
 
-func init() {
+func Execute() {
 	// global flags
-	RootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "Kubernetes namespace")
-	RootCmd.PersistentFlags().IntVarP(&scanTimeOut, "timeout", "t", 120, "Scan timeout in seconds")
-	RootCmd.PersistentFlags().StringVarP(&scanURL, "url", "u", "https://v2.kubesec.io", "URL to send the request for scanning")
+	rootCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "Kubernetes namespace")
+	rootCmd.PersistentFlags().IntVarP(&scanTimeOut, "timeout", "t", 120, "Scan timeout in seconds")
+	rootCmd.PersistentFlags().StringVarP(&scanURL, "url", "u", "https://v2.kubesec.io", "URL to send the request for scanning")
+	rootCmd.PersistentFlags().StringVarP(&kubeconfig, "kubeconfig", "k", "", "Path to kubeconfig, overrides KUBECONFIG environment variable")
 
-	// client
-	kubeClient = loadConfig()
 	serializer = kjson.NewYAMLSerializer(kjson.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
 
 	// commands
-	RootCmd.AddCommand(versionCmd)
-	RootCmd.AddCommand(podCmd)
-	RootCmd.AddCommand(deploymentCmd)
-	RootCmd.AddCommand(daemonsetCmd)
-	RootCmd.AddCommand(statefulsetCmd)
+	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(podCmd)
+	rootCmd.AddCommand(deploymentCmd)
+	rootCmd.AddCommand(daemonsetCmd)
+	rootCmd.AddCommand(statefulsetCmd)
+
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
 }
 
-func loadConfig() *kubernetes.Clientset {
-	home := os.Getenv("HOME")
-	if len(home) == 0 {
-		panic("no home")
-	}
-	clientSet, err := clientSet(home + "/.kube/config")
+// newKubeClient creates a new Kubernetes client
+func newKubeClient(kubeconfig string) (*kubernetes.Clientset, error) {
+	config, err := newClientConfig(kubeconfig)
 	if err != nil {
-		panic(err)
-	}
-	return clientSet
-}
-
-func clientSet(kubeconfig string) (*kubernetes.Clientset, error) {
-	kubeconfigBytes, err := ioutil.ReadFile(kubeconfig)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to create client config: %w", err)
 	}
 
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigBytes)
+	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, err
-	}
-
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to create a new Clienset: %w", err)
 	}
 
 	return clientset, nil
+}
+
+// newClientConfig creates a new rest client config by fetching
+// kubeconfig in the following order:
+// 1) CLI flag, 2) KUBECONFIG env var, 3) $HOME/.kube/config
+func newClientConfig(kubeconfig string) (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// if empty, it will try to load it from other places
+	loadingRules.ExplicitPath = kubeconfig
+
+	configOverrides := &clientcmd.ConfigOverrides{}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+
+	config, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create client config: %w", err)
+	}
+
+	return config, nil
 }

--- a/pkg/cmd/root_test.go
+++ b/pkg/cmd/root_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNewClient tests the creation of the Kubeconfig from
+// different location with the overrides.
+func TestNewClient(t *testing.T) {
+	var (
+		// The URL, is used to determine if the right kubeconfig is loaded
+		kubeconfigTemplate = `apiVersion: v1
+clusters:
+- cluster:
+    server: _URL_
+  name: kind-kind
+contexts:
+- context:
+    cluster: kind-kind
+    user: kind-kind
+  name: kind-kind
+current-context: kind-kind
+kind: Config
+preferences: {}
+users:
+- name: kind-kind
+`
+
+		kubeconfigFromUser       = strings.Replace(kubeconfigTemplate, "_URL_", "kubeconfig-from-user", 1)
+		kubeconfigFromEnv        = strings.Replace(kubeconfigTemplate, "_URL_", "kubeconfig-from-env", 1)
+		kubeconfigFromDefaultLoc = strings.Replace(kubeconfigTemplate, "_URL_", "kubeconfig-from-default-loc", 1)
+	)
+
+	var tests = []struct {
+		name              string
+		setFromUser       bool
+		setFromEnv        bool
+		SetFromDefaultLoc bool
+		expectedHost      string
+	}{
+		{
+			name:         "Kubeconfig is provided from CLI",
+			setFromUser:  true,
+			expectedHost: "kubeconfig-from-user",
+		},
+		{
+			name:         "Kubeconfig is provided on with env var KUBECONFIG",
+			setFromEnv:   true,
+			expectedHost: "kubeconfig-from-env",
+		},
+		{
+			name:              "Kubeconfig is set from the default loc, not provided from CLI nor env",
+			SetFromDefaultLoc: true,
+			expectedHost:      "kubeconfig-from-default-loc",
+		},
+		{
+			name:         "Kubeconfig is provided from CLI and env",
+			setFromUser:  true,
+			setFromEnv:   true,
+			expectedHost: "kubeconfig-from-user",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			kubeconfigPath := ""
+			dir := t.TempDir()
+
+			switch {
+			case tt.setFromUser:
+				kubeconfigPath = filepath.Join(dir, "config")
+				err := os.WriteFile(kubeconfigPath, []byte(kubeconfigFromUser), 0400)
+				if err != nil {
+					t.Error(err)
+				}
+			case tt.setFromEnv:
+				kubeconfigPath = filepath.Join(dir, "config")
+				err := os.WriteFile(kubeconfigPath, []byte(kubeconfigFromEnv), 0400)
+				if err != nil {
+					t.Error(err)
+				}
+
+				t.Setenv("KUBECONFIG", kubeconfigPath)
+			case tt.SetFromDefaultLoc:
+				home := dir
+				t.Setenv("HOME", home)
+				err := os.Mkdir(filepath.Join(home, ".kube"), 0700)
+				if err != nil {
+					t.Error(err)
+				}
+				kubeconfigPath = filepath.Join(home, ".kube/config")
+
+				err = os.WriteFile(kubeconfigPath, []byte(kubeconfigFromDefaultLoc), 0400)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+
+			config, err := newClientConfig(kubeconfigPath)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if config.Host != tt.expectedHost {
+				t.Errorf("Expected Kubeconfig host (location), got: %s, want: %s", config.Host, tt.expectedHost)
+			}
+
+			client, err := newKubeClient(kubeconfigPath)
+			if err != nil {
+				t.Error(err)
+			}
+
+			if client == nil {
+				t.Errorf("client should not be nil")
+			}
+		})
+	}
+}

--- a/pkg/cmd/statefulset.go
+++ b/pkg/cmd/statefulset.go
@@ -24,6 +24,11 @@ var statefulsetCmd = &cobra.Command{
 		}
 		name := args[0]
 
+		kubeClient, err := newKubeClient(kubeconfig)
+		if err != nil {
+			return err
+		}
+
 		var buffer bytes.Buffer
 		writer := bufio.NewWriter(&buffer)
 


### PR DESCRIPTION
Kubeconfig is now loaded in this order:

1. CLI flag: kubectl scan --kubeconfig config pod
2. KUBECONFIG env var: KUBECONFIG=config kubectl scan pod
3. $HOME/.kube/config: kubectl scan pod

fixes #126

Other minor changes:

* remove the help when an error occurs
* remove unsued flag configuration
* do not output error messages twice

Signed-off-by: ludo <controlplane@spiarh.fr>